### PR TITLE
Add support for EFR32xG23, device/debug lock/erase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Subdirectory _[efm32s2]_ contains a preliminary OpenOCD flash driver for Silicon Laboratories EFM32 series 2 MCUs, like EFM32PG22,
-based on OpenOCD's driver for series 0 and 1 MCUs, [efm32][efm32c],
+or EFR32FG23, based on OpenOCD's driver for series 0 and 1 MCUs, [efm32][efm32c],
 which has been adapted as far as necessary for basic functionality.
 Features other than flashing or debugging, like page locking,
 may still not work correctly, this hasn't been tested yet.
@@ -14,6 +14,7 @@ A number of details are different in series 2, as compared to series 0 and 1:
 	which made an adjustment of the flash write assembly code neccessary.
 -	To be able to use the MSC peripheral, its clock must be enabled in the CMU.
 -	The RAM starts at a different address, 0x2... instead of 0x1....
+-	Flash base address is not 0x0 but 0x08000000 for EFR32xG23 (but still 0x0 for xG22).
 
 Since the work area address (i.e. the start of ram) gets configured in tcl/target/efm32.cfg,
 it has been decided to create a new `efm32s2` target in tcl/target/efm32s2.cfg,
@@ -33,9 +34,9 @@ In this project's working directory, clone OpenOCD's official Github mirror repo
 
 Checkout a revision compatible to this EFM32 series 2 extension:
 
-	git checkout 42a0bf3
+	git checkout 94e7535
 
-... which sets the OpenOCD source directory to a few commits after v0.11.0.
+... which sets the OpenOCD source directory to where this author last tested building. Bumping further might work, but YMMV.
 
 Initialize submodules:
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@ which has been adapted as far as necessary for basic functionality.
 Features other than flashing or debugging, like page locking,
 may still not work correctly, this hasn't been tested yet.
 
+Some functionality for enabling debug lock and issuing a device reset via DCI to lock/unlock a device
+has been implemented in efm32s2.cfg, and the tcl will attempt to notify the user if the device is locked.
+Also this implementation can serve as a good reference for implementing the mechanisms describeed in SiLabs
+appnotes [AN1303] and [AN1190].
+
 [efm32s2]: ./efm32s2
 [efm32c]: https://github.com/ntfreak/openocd/blob/42a0bf3c360c1eae418223f0ab535b4d7accae83/src/flash/nor/efm32.c
+[AN1190]: https://www.silabs.com/documents/public/application-notes/an1190-efr32-secure-debug.pdf
+[AN1303]: https://www.silabs.com/documents/public/application-notes/an1303-efr32-dci-swd-programming.pdf
 
 A number of details are different in series 2, as compared to series 0 and 1:
 
@@ -15,6 +22,7 @@ A number of details are different in series 2, as compared to series 0 and 1:
 -	To be able to use the MSC peripheral, its clock must be enabled in the CMU.
 -	The RAM starts at a different address, 0x2... instead of 0x1....
 -	Flash base address is not 0x0 but 0x08000000 for EFR32xG23 (but still 0x0 for xG22).
+-	Debug/device lock/erase has now moved to it's own SWD AP called DCI.
 
 Since the work area address (i.e. the start of ram) gets configured in tcl/target/efm32.cfg,
 it has been decided to create a new `efm32s2` target in tcl/target/efm32s2.cfg,

--- a/efm32s2/efm32s2.cfg
+++ b/efm32s2/efm32s2.cfg
@@ -48,4 +48,217 @@ if {![using_hla]} {
    # if srst is not fitted use SYSRESETREQ to
    # perform a soft reset
    cortex_m reset_config sysresetreq
+
+   $_TARGETNAME configure -event examine-fail efm32s2_dci_read_se_status
+}
+
+proc efm32s2_dci_connect {} {
+	set target [target current]
+	set dap [$target cget -dap]
+
+   # Read DP_IDCODE
+   set dp_id [$dap dpreg 0]
+
+   if {$dp_id != 0x6BA02477} {
+      echo "Error: invalid dp id for series2 efm32"
+      return
+   }
+
+   poll off
+
+   # Clear error and sticky flag conditions
+   # DP_ABORT = ORUNERRCLR | WDERRCLR STKERRCLR | STKCMPCLR
+   $dap dpreg 0 0x1E
+
+   # DP_CTRL = CSYSPWRUPREQ | CDBGPWRUPREQ
+
+   $dap dpreg 0x04 0x50000000
+
+   # DP_SELECT for DCP AP register bank 0
+   $dap dpreg 0x08 0x01000000
+
+   # Set CSW
+   $dap apreg 1 0x00 0x22000002
+
+   # Write AP_TAR = DCIID
+   $dap apreg 1 0x04 0x10FC
+
+   # Read DP DRW
+   $dap dpreg 0x0C
+
+   # Read AP RDBUFF
+   set DCIID [$dap apreg 1 0x0C]
+   if {$DCIID != 0xdc11d} {
+      echo "Failed to read correct DCIID"
+   } else {
+      echo "Successfully connected to DCI"
+   }
+}
+
+proc efm32s2_dci_read_status {} {
+   set target [target current]
+	set dap [$target cget -dap]
+
+   # AP_TAR = DCISTATUS
+   $dap apreg 1 0x04 0x1008
+
+   set dcistatus [$dap apreg 1 0x0C]
+   set dcistatus [$dap dpreg 0x0C]
+
+   return $dcistatus
+}
+
+proc efm32s2_dci_write_cmd { dci_write_word } {
+   set target [target current]
+	set dap [$target cget -dap]
+
+   for {set i 0} {1} {incr i} {
+      if {$i >= 100} {
+         echo "$target DCI write timeout, unable to write command"
+         return
+      }
+
+      set dcistatus [efm32s2_dci_read_status]
+      if {$dcistatus & 1} {
+         echo "DCI WPENDING bit set, retrying"
+         sleep 10
+         continue
+      }
+
+      if {$dcistatus & 0x100} {
+         echo "DCI RDATAVALID is set, can't write to DCIWRITE"
+         return
+      }
+
+      # AP_TAR = DCIWDATA
+      $dap apreg 1 0x04 0x1000
+
+      # Write word
+      $dap apreg 1 0x0C $dci_write_word
+      return
+   }
+}
+
+proc efm32s2_dci_read_response {} {
+   set target [target current]
+	set dap [$target cget -dap]
+
+   for {set i 0} {1} {incr i} {
+      if {$i >= 100} {
+         echo "$target DCI read timeout"
+         return
+      }
+
+      set dcistatus [efm32s2_dci_read_status]
+
+      if {$dcistatus & 0x100} {
+         # AP_TAR = DCIRDATA
+         $dap apreg 1 0x04 0x1004
+
+         set dciread [$dap apreg 1 0x0C]
+         set dciread [$dap dpreg 0x0C]
+         return $dciread
+      } else {
+         echo "DCI RDATAVALID is not set, retrying"
+         sleep 10
+         continue
+      }
+   }
+}
+
+proc efm32s2_dci_device_erase {} {
+   efm32s2_dci_connect
+   efm32s2_dci_write_cmd 8
+   efm32s2_dci_write_cmd 0x430F0000
+
+   sleep 2000
+   echo "Device erase command sent. Device should now be erased and debug should be available again after a reset"
+}
+
+proc efm32s2_dci_device_lock {} {
+   echo "Attempting to activate debug lock..."
+   efm32s2_dci_connect
+   efm32s2_dci_write_cmd 8
+   efm32s2_dci_write_cmd 0x430C0000
+
+   set recvlen [efm32s2_dci_read_response]
+
+   if {$recvlen & 0xFFFF0000} {
+      echo "command response was not OK, got $recvlen as command response. Can't continue."
+      return
+   }
+
+   sleep 100
+
+   efm32s2_dci_read_se_status
+}
+
+proc efm32s2_dci_read_se_status {} {
+   efm32s2_dci_connect
+
+   # Write len
+   efm32s2_dci_write_cmd 8
+
+   # Write cmd
+   efm32s2_dci_write_cmd 0xFE010000
+
+   set recvlen [efm32s2_dci_read_response]
+
+   if {$recvlen & 0xFFFF0000} {
+      echo "command response was not OK, got $recvlen as command response. Can't continue."
+      return
+   }
+
+   set debuglock_idx 3
+
+   if {$recvlen == 0x28} {
+      set debuglock_idx 7
+   }
+
+   # decrement length word
+   set recvlen [expr {$recvlen - 4}]
+
+   for {set i 0} {1} {incr i} {
+      if {$recvlen <= 0} {
+         break
+      }
+
+      set recvlen [expr {$recvlen - 4}]
+      set sestatusarray($i) [efm32s2_dci_read_response]
+   }
+
+   echo "DCI SESTATUS response:"
+   set sestatusarray
+
+   set debuglock $sestatusarray($debuglock_idx)
+
+   if {$debuglock & 0x01} {
+      echo "Debug lock (config): Enabled"
+   } else {
+      echo "Debug lock (config): Disabled"
+   }
+
+   if {$debuglock & 0x02} {
+      echo "Device erase: Enabled"
+   } else {
+      echo "Device erase: Disabled"
+   }
+
+   if {$debuglock & 0x04} {
+      echo "Secure debug: Enabled"
+   } else {
+      echo "Secure debug: Disabled"
+   }
+
+   if {$debuglock & 0x20} {
+      echo "Debug lock (hw status): Enabled"
+      echo "\n"
+      echo " * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
+      echo "  You will not be able to communicate with this device"
+      echo "  unless you perform a device erase (if available, indicated above)!"
+      echo "  Try efm32s2_dci_device_erase to attempt erase."
+      echo " * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n"
+   } else {
+      echo "Debug lock (hw status): Disabled"
+   }
 }


### PR DESCRIPTION
I've done some work getting the EFR32xG23 to work with your previous much appreciated series 2 patches. xG23 changes flash base address along with the CMU_CLKEN1 bits just to be helpful.

I also implemented parts of the DCI SE interface so that a locked device can be unlocked and vice versa. No support for secure debug or disabling device erase yet, but at least DCI communication works.