### PR TITLE
EFM32 series 2: Additional support for xG23 family parts.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,9 @@ cd openocd
 ./configure \
 	--prefix=/opt/openocd-emf32s2-cmsis-dap\
 	--without-capstone\
+	--enable-cmsis-dap\
+	--enable-ftdi\
+	--enable-jlink\
 	--disable-presto\
 	--disable-stlink\
 	--disable-rshim\

--- a/dist/_iface.sh
+++ b/dist/_iface.sh
@@ -1,2 +1,8 @@
+# Enable to run CMIS-DAP interface
 iface=cmsis-dap
+
+# Enable to run FTDI interface
 #iface=ftdi_ft232h
+
+# Enable to run Segger JLink interface
+#iface=jlink

--- a/dist/debug.sh
+++ b/dist/debug.sh
@@ -1,8 +1,8 @@
+# Setup interface
 . ./_iface.sh
+# To run on xG23 targets, change below to 'target/efm32s2_g23.cfg'
 ./bin/openocd-efm32s2 -s scripts -f interface/$iface.cfg \
 	-c 'transport select swd' \
 	-f target/efm32s2.cfg\
 	-c init \
 	-c halt \
-
-

--- a/dist/flash.sh
+++ b/dist/flash.sh
@@ -1,4 +1,6 @@
+# Setup interface
 . ./_iface.sh
+# To run on xG23 targets, change below to 'target/efm32s2_g23.cfg'
 ./bin/openocd-efm32s2 -s scripts -f interface/$iface.cfg \
 	-c 'transport select swd' \
 	-f target/efm32s2.cfg\
@@ -7,6 +9,5 @@
 	-c 'flash probe 0' \
 	-c 'flash banks' \
 	-c 'flash list' \
-	-c 'flash write_image erase '$1 \
+	-c 'flash write_image erase '$1' $FLASHBASE' \
 	-c exit\
-

--- a/dist/ident.sh
+++ b/dist/ident.sh
@@ -1,4 +1,6 @@
+# Setup interface
 . ./_iface.sh
+# To run on xG23 targets, change below to 'target/efm32s2_g23.cfg'
 ./bin/openocd-efm32s2 -s scripts -f interface/$iface.cfg \
 	-c 'transport select swd' \
 	-f target/efm32s2.cfg\
@@ -8,4 +10,3 @@
 	-c 'flash banks' \
 	-c 'flash list' \
 	-c exit\
-

--- a/dist/verify.sh
+++ b/dist/verify.sh
@@ -1,4 +1,6 @@
+# Setup interface
 . ./_iface.sh
+# To run on xG23 targets, change below to 'target/efm32s2_g23.cfg'
 ./bin/openocd-efm32s2 -s scripts -f interface/$iface.cfg \
 	-c 'transport select swd' \
 	-f target/efm32s2.cfg\
@@ -7,6 +9,5 @@
 	-c 'flash probe 0' \
 	-c 'flash banks' \
 	-c 'flash list' \
-	-c 'flash verify_image '$1 \
+	-c 'flash verify_image '$1' $FLASHBASE' \
 	-c exit\
-

--- a/efm32s2/efm32s2.cfg
+++ b/efm32s2/efm32s2.cfg
@@ -31,6 +31,14 @@ if { [info exists CPUTAPID] } {
    }
 }
 
+# Family group 22 has flash base address 0x00000000
+# Family group 23 has flash base address 0x08000000
+if { [info exists FLASHBASE] } {
+	set _FLASHBASE $FLASHBASE
+} else {
+	set _FLASHBASE 0x00000000
+}
+
 swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
 dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
 
@@ -42,7 +50,8 @@ target create $_TARGETNAME cortex_m -dap $_CHIPNAME.dap
 $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0
 
 set _FLASHNAME $_CHIPNAME.flash
-flash bank $_FLASHNAME efm32s2 0 0 0 0 $_TARGETNAME
+
+flash bank $_FLASHNAME efm32s2 $_FLASHBASE 0 0 0 $_TARGETNAME
 flash bank userdata.flash efm32s2 0x0FE00000 0 0 0 $_TARGETNAME
 
 if {![using_hla]} {

--- a/efm32s2/efm32s2_g23.cfg
+++ b/efm32s2/efm32s2_g23.cfg
@@ -1,0 +1,11 @@
+#
+# Silicon Labs (formerly Energy Micro) EFM32 target
+#
+# Note: All EFM32 chips have SWD support, but only newer series 1
+# chips have JTAG support.
+#
+
+# Family group 22 has flash base address 0x00000000
+# Family group 23 has flash base address 0x08000000
+set FLASHBASE 0x08000000
+source [find target/efm32s2.cfg]

--- a/mkdist.sh
+++ b/mkdist.sh
@@ -11,7 +11,9 @@ strip -s bin/openocd-efm32s2
 
 mkdir -p scripts/interface
 cp $src/tcl/interface/cmsis-dap.cfg scripts/interface
+cp $src/tcl/interface/jlink.cfg scripts/interface
 
 mkdir -p scripts/target
 cp $src/tcl/target/efm32s2.cfg scripts/target
+cp $src/tcl/target/efm32s2_g23.cfg scripts/target
 cp $src/tcl/target/swj-dp.tcl scripts/target

--- a/setup-openocd-src.sh
+++ b/setup-openocd-src.sh
@@ -31,6 +31,7 @@ cmd git submodule -q update
 msg copying efm32s2 files to the OpenOCD source tree
 cmd cp ../efm32s2/efm32s2.c src/flash/nor/
 cmd cp ../efm32s2/efm32s2.cfg tcl/target/
+cmd cp ../efm32s2/efm32s2_g23.cfg tcl/target/
 cmd patch -p1 -i ../efm32s2/adjust_openocd.patch
 
 


### PR DESCRIPTION
The reg base to access MSC and CMU is now using non secured addresses.